### PR TITLE
Support multiple fields in --group-by

### DIFF
--- a/ngxtop/ngxtop.py
+++ b/ngxtop/ngxtop.py
@@ -210,6 +210,7 @@ class SQLProcessor(object):
     def process(self, records):
         self.begin = time.time()
         insert = 'insert into log (%s) values (%s)' % (self.column_list, self.holder_list)
+        logging.info('sqlite insert: %s', insert)
         with closing(self.conn.cursor()) as cursor:
             for r in records:
                 cursor.execute(insert, r)
@@ -300,7 +301,12 @@ def build_processor(arguments):
 
     for label, query in report_queries:
         logging.info('query for "%s":\n %s', label, query)
-    processor = SQLProcessor(report_queries, fields)
+
+    processor_fields = []
+    for field in fields:
+        processor_fields.extend(field.split(','))
+
+    processor = SQLProcessor(report_queries, processor_fields)
     return processor
 
 


### PR DESCRIPTION
This allows --group-by to take a comma-separated list of field names,
and processes the field list before passing it to the SQLProcessor. When
displaying the results, it displays as two separate fields.
