### PR TITLE
Add option to specify a custom log format defined in a file

### DIFF
--- a/ngxtop/config_parser.py
+++ b/ngxtop/config_parser.py
@@ -1,9 +1,11 @@
 """
 Nginx config parser and pattern builder.
 """
+import ConfigParser
 import os
 import re
 import subprocess
+import sys
 
 from pyparsing import Literal, Word, ZeroOrMore, OneOrMore, Group, \
     printables, quotedString, pythonStyleComment, removeQuotes
@@ -120,6 +122,22 @@ def detect_log_config(arguments):
     if format_name not in log_formats:
         error_exit('Incorrect format name set in config for access log file "%s"' % log_path)
     return log_path, log_formats[format_name]
+
+
+def detect_custom_log(arguments):
+    """
+    Get the custom log format specified in a custom config file
+    :return: log format
+    """
+    custom_log = arguments['--custom-log-format']
+    if not os.path.exists(custom_log):
+        error_exit('Custom format config not found: %s' % custom_log)
+
+    config = ConfigParser.ConfigParser()
+    config.read(custom_log)
+    log_format = config.get('log_format', 'log_format')
+    log_format = log_format.replace('\n', '').replace('\'', '')
+    return log_format
 
 
 def build_pattern(log_format):

--- a/ngxtop/ngxtop.py
+++ b/ngxtop/ngxtop.py
@@ -28,6 +28,7 @@ Options:
     Advanced / experimental options:
     -c <file>, --config <file>  allow ngxtop to parse nginx config file for log format and location.
     -i <filter-expression>, --filter <filter-expression>  filter in, records satisfied given expression are processed.
+    -j <file>, --custom-log-format <file> specify log format in a file.
     -p <filter-expression>, --pre-filter <filter-expression> in-filter expression to check in pre-parsing phase.
 
 Examples:
@@ -74,7 +75,13 @@ except ImportError:
 from docopt import docopt
 import tabulate
 
-from config_parser import detect_log_config, detect_config_path, extract_variables, build_pattern
+from config_parser import (
+    detect_log_config,
+    detect_config_path,
+    detect_custom_log,
+    extract_variables,
+    build_pattern,
+)
 from utils import error_exit
 
 
@@ -339,11 +346,15 @@ def setup_reporter(processor, arguments):
 def process(arguments):
     access_log = arguments['--access-log']
     log_format = arguments['--log-format']
+    custom_log_format = arguments['--custom-log-format']
+
     if access_log is None and not sys.stdin.isatty():
         # assume logs can be fetched directly from stdin when piped
         access_log = 'stdin'
     if access_log is None:
         access_log, log_format = detect_log_config(arguments)
+    if custom_log_format:
+        log_format = detect_custom_log(arguments)
 
     logging.info('access_log: %s', access_log)
     logging.info('log_format: %s', log_format)


### PR DESCRIPTION
My nginx.conf is not world-readable, but that is where the custom log format is defined. It seems simpler to specify my own config file where a custom log format can be defined.
