### PR TITLE
Fix ${var} variables

### DIFF
--- a/ngxtop/config_parser.py
+++ b/ngxtop/config_parser.py
@@ -12,7 +12,7 @@ from .utils import choose_one, error_exit
 
 
 REGEX_SPECIAL_CHARS = r'([\.\*\+\?\|\(\)\{\}\[\]])'
-REGEX_LOG_FORMAT_VARIABLE = r'\$([a-z0-9\_]+)'
+REGEX_LOG_FORMAT_VARIABLE = r'\$(?:\\{)?([a-z0-9\_]+)(?:\\})?'
 LOG_FORMAT_COMBINED = '$remote_addr - $remote_user [$time_local] ' \
                       '"$request" $status $body_bytes_sent ' \
                       '"$http_referer" "$http_user_agent"'


### PR DESCRIPTION
Hello,
I had error with log format containing variables escaped by {} for concatenation with strings was not properly parsed and ngxtop just dropped all log. This fix solves the issue.
