### PR TITLE
use non-greedy regex to match a log

### DIFF
--- a/ngxtop/config_parser.py
+++ b/ngxtop/config_parser.py
@@ -133,7 +133,7 @@ def build_pattern(log_format):
     elif log_format == 'common':
         log_format = LOG_FORMAT_COMMON
     pattern = re.sub(REGEX_SPECIAL_CHARS, r'\\\1', log_format)
-    pattern = re.sub(REGEX_LOG_FORMAT_VARIABLE, '(?P<\\1>.*)', pattern)
+    pattern = re.sub(REGEX_LOG_FORMAT_VARIABLE, '(?P<\\1>.*?)', pattern)
     return re.compile(pattern)
 
 


### PR DESCRIPTION
Hi Lebinh
I find an error in matching if my nginx log's fields are more than pre-defined, this error causes ngxtop cannot output any stats result.

My nginx log looks like:
_10.18.110.79 - - [31/Mar/2016:14:19:00 +0800] "GET /favicon.ico HTTP/1.1" 200 1406 "-" "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 SE 2.X MetaSr 1.0" "-" "yangchao-g.jifen.360.cn" "80" 0.000_

after $http_user_agent, I have 3 extra fields.
the current ngxtop matching result is:
{
     'remote_addr': '10.18.110.79',
     'remote_user': '-',
     'time_local': '31/Mar/2016:14:19:00 +0800',
     'request': 'GET /favicon.ico HTTP/1.1" 200 1406 "-',
     'status': '"Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 SE 2.X MetaSr 1.0"',
     'body_bytes_sent': '"-"',
     'http_referer': 'yangchao-g.jifen.360.cn',
     'http_user_agent': '80',
}

you see that the request field eats more bytes than it should.

the fix is to use non-greedy-matching regex.
